### PR TITLE
Update postinstall script and adjust Obsidian workspace settings

### DIFF
--- a/docs/md/.obsidian/graph.json
+++ b/docs/md/.obsidian/graph.json
@@ -17,6 +17,6 @@
   "repelStrength": 10,
   "linkStrength": 1,
   "linkDistance": 250,
-  "scale": 1.577984258262967,
+  "scale": 1.665641377611553,
   "close": false
 }

--- a/docs/md/.obsidian/workspace.json
+++ b/docs/md/.obsidian/workspace.json
@@ -11,14 +11,10 @@
             "id": "35fb8fa75fa12592",
             "type": "leaf",
             "state": {
-              "type": "markdown",
-              "state": {
-                "file": "(DOC)(memory-data-types-and-validation-schemas)(ac69f5f1-456a-44e3-8e63-cd39c29dd351).md",
-                "mode": "source",
-                "source": false
-              },
-              "icon": "lucide-file",
-              "title": "(DOC)(memory-data-types-and-validation-schemas)(ac69f5f1-456a-44e3-8e63-cd39c29dd351)"
+              "type": "graph",
+              "state": {},
+              "icon": "lucide-git-fork",
+              "title": "Graph view"
             }
           }
         ]
@@ -170,6 +166,7 @@
   },
   "active": "35fb8fa75fa12592",
   "lastOpenFiles": [
+    "(DOC)(memory-data-types-and-validation-schemas)(ac69f5f1-456a-44e3-8e63-cd39c29dd351).md",
     "(DOC)(fresh-test-memory-c)(8f26877a-3bb8-4cc9-b54f-944858bc9771).md",
     "(DOC)(fresh-test-memory-b)(126cd8a0-aca7-4677-a8a3-a8e0b3954fc5).md",
     "(DOC)(fresh-test-memory-a)(fa5e0eb2-7677-4b54-9308-3ca34990bfca).md",
@@ -194,7 +191,6 @@
     "(DOC)(final-test-memory-2)(5d82fe46-e5c2-4f13-bb03-66d18da30cf7).md",
     "(DOC)(final-test-memory-1)(dd53def7-e5ef-4f30-8f2e-c0f0dcff61e8).md",
     "(DOC)(clean-test-memory-b)(a6fef3c7-1944-49d9-a1fb-4b2195383423).md",
-    "(DOC)(clean-test-memory-a)(3a2b3324-bf5f-45a5-bf2b-252f6e08692e).md",
-    "(DOC)(target-test-memory)(5023ac8d-525a-4d61-950b-048b53e232a1).md"
+    "(DOC)(clean-test-memory-a)(3a2b3324-bf5f-45a5-bf2b-252f6e08692e).md"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=24.0.0"
   },
   "scripts": {
-    "postinstall": "pnpm install --ignore-scripts && pnpm build && cd packages/shared && npm rebuild sqlite3",
+    "postinstall": "pnpm install --ignore-workspace --ignore-scripts && pnpm build && cd packages/shared && npm rebuild sqlite3",
     "build": "pnpm -r build",
     "build:shared": "pnpm --filter @llm-mem/shared build",
     "build:cli": "pnpm --filter @llm-mem/cli build",


### PR DESCRIPTION
- Modified the `postinstall` script in `package.json` to include `--ignore-workspace` for improved package management.
- Updated the `scale` value in `graph.json` for better visualization in Obsidian.
- Changed the state type in `workspace.json` from `markdown` to `graph`, and updated the icon and title for clarity in the workspace view.
- Ensured the last open files list in `workspace.json` remains consistent with recent document usage.