### PR TITLE
Refactor validation logic to support custom categories in configuration

### DIFF
--- a/packages/cli/src/validation.ts
+++ b/packages/cli/src/validation.ts
@@ -2,7 +2,12 @@ import path from "node:path";
 import { z } from "zod";
 import { CoverageConfig, CoverageOptions } from "./types.js";
 
-export const allowedCategories = ["DOC", "ADR", "CTX"] as const;
+/**
+ * Default categories used when no categories are specified.
+ * This is kept for documentation and default value purposes only.
+ * Custom categories are allowed via configuration files.
+ */
+export const defaultCategories = ["DOC", "ADR", "CTX"] as const;
 
 const NonEmptyString = z.string().min(1, "must be a non-empty string");
 
@@ -30,7 +35,7 @@ const GlobArray = z
 
 export const CoverageOptionsSchema = z.object({
     config: NonEmptyString.optional(),
-    categories: z.array(z.enum(allowedCategories)).optional(),
+    categories: z.array(NonEmptyString).optional(),
     threshold: z.number().min(0).max(100).optional(),
     exclude: GlobArray,
     include: GlobArray,
@@ -63,7 +68,7 @@ export const CoverageConfigSchema = z.object({
     thresholds: ThresholdsSchema,
     exclude: GlobArray,
     include: GlobArray,
-    categories: z.array(z.enum(allowedCategories)).optional(),
+    categories: z.array(NonEmptyString).optional(),
     memoryStorePath: NonEmptyString.optional(),
     indexPath: NonEmptyString.optional(),
 });

--- a/packages/cli/tests/config-parser.test.ts
+++ b/packages/cli/tests/config-parser.test.ts
@@ -71,6 +71,27 @@ describe("config-parser", () => {
     createdFiles.push(file);
     await expect(parser.parseConfig(file)).rejects.toBeTruthy();
   });
+
+  it("parses config with custom categories and validates successfully", async () => {
+    const parser = new BasicConfigParser();
+    const file = join(tmpdir(), `.coverage_${Date.now()}.json`);
+    const cfg = {
+      thresholds: { overall: 80 },
+      exclude: ["node_modules/**"],
+      include: ["src/**/*.ts"],
+      categories: ["CUSTOM_CATEGORY", "ANOTHER_CATEGORY", "DOC"]
+    };
+    await fs.writeFile(file, JSON.stringify(cfg), "utf8");
+    createdFiles.push(file);
+
+    const parsed = await parser.parseConfig(file);
+    expect(parsed.categories).toEqual(["CUSTOM_CATEGORY", "ANOTHER_CATEGORY", "DOC"]);
+    
+    // Verify the parsed config can be validated
+    const { validateCoverageConfig } = await import("../src/validation.js");
+    const validation = validateCoverageConfig(parsed);
+    expect(validation.ok).toBe(true);
+  });
 });
 
 

--- a/packages/cli/tests/coverage-granular.test.ts
+++ b/packages/cli/tests/coverage-granular.test.ts
@@ -121,11 +121,12 @@ describe("Granular coverage analysis (Step 8)", () => {
     }]);
 
     const report = await svc.generateReport({ scanSourceFiles: false });
-    const fr = report.files.find(f => f.path === "tests/tmp/granular/granular_mixed.ts")!;
-    expect(fr.functionsTotal).toBe(2);
-    expect(fr.functionsCovered).toBe(2);
-    expect(fr.classesTotal).toBe(1);
-    expect(fr.classesCovered).toBe(0);
+    const fr = report.files.find(f => f.path === "tests/tmp/granular/granular_mixed.ts");
+    expect(fr).toBeDefined();
+    expect(fr?.functionsTotal).toBe(2);
+    expect(fr?.functionsCovered).toBe(2);
+    expect(fr?.classesTotal).toBe(1);
+    expect(fr?.classesCovered).toBe(0);
   });
 
   it("treats file-only source as covering all symbols (edge case)", async () => {

--- a/packages/cli/tests/validation.test.ts
+++ b/packages/cli/tests/validation.test.ts
@@ -99,11 +99,26 @@ describe("Validation Functions", () => {
             });
         });
 
-        it("should reject invalid categories", () => {
+        it("should accept custom categories", () => {
+            const customCategories = [
+                { categories: ["CUSTOM"] },
+                { categories: ["DOC", "CUSTOM", "ANOTHER"] },
+                { categories: ["MY_CATEGORY"] },
+            ];
+
+            customCategories.forEach(options => {
+                const result = CoverageOptionsSchema.safeParse(options);
+                expect(result.success).toBe(true);
+            });
+        });
+
+        it("should reject invalid category values", () => {
             const invalidCategories = [
-                { categories: ["INVALID"] },
-                { categories: ["DOC", "INVALID"] },
                 { categories: [123] },
+                { categories: [""] },
+                { categories: ["VALID", ""] },
+                { categories: [null] },
+                { categories: [undefined] },
             ];
 
             invalidCategories.forEach(options => {
@@ -179,7 +194,7 @@ describe("Validation Functions", () => {
 
         it("should provide detailed error messages", () => {
             const invalidOptions: CoverageOptions = {
-                categories: ["INVALID" as any],
+                categories: ["" as any],
             };
 
             const result = validateOptionsStrict(invalidOptions);
@@ -239,6 +254,32 @@ describe("Validation Functions", () => {
 
             const result = CoverageConfigSchema.safeParse(validNestedThresholds);
             expect(result.success).toBe(true);
+        });
+
+        it("should accept custom categories in config", () => {
+            const customCategoryConfigs = [
+                { categories: ["CUSTOM"] },
+                { categories: ["DOC", "CUSTOM", "ANOTHER"] },
+                { categories: ["MY_CATEGORY", "OTHER_CATEGORY"] },
+            ];
+
+            customCategoryConfigs.forEach(config => {
+                const result = CoverageConfigSchema.safeParse(config);
+                expect(result.success).toBe(true);
+            });
+        });
+
+        it("should reject invalid category values in config", () => {
+            const invalidCategoryConfigs = [
+                { categories: [123] },
+                { categories: [""] },
+                { categories: ["VALID", ""] },
+            ];
+
+            invalidCategoryConfigs.forEach(config => {
+                const result = CoverageConfigSchema.safeParse(config);
+                expect(result.success).toBe(false);
+            });
         });
     });
 


### PR DESCRIPTION
- Renamed `allowedCategories` to `defaultCategories` for clarity and documentation purposes.
- Updated `CoverageOptionsSchema` and `CoverageConfigSchema` to accept custom categories as non-empty strings instead of enum values.
- Added tests to validate successful parsing and acceptance of custom categories in configuration files, along with checks for invalid category values.
- Enhanced existing tests to ensure robust validation of category inputs.