### PR TITLE
Add reindexing management to MemoryServiceManager and update search i…

### DIFF
--- a/packages/shared/src/memory/memory-service.ts
+++ b/packages/shared/src/memory/memory-service.ts
@@ -706,44 +706,31 @@ export class MemoryService {
     };
   }
 
-  async linkMemories(params: LinkRequest): Promise<{
-    source_id: string;
-    target_id: string;
-    success: boolean;
-    message: string;
-  }> {
-    await this.initialize();
-    const { source_id, target_id, link_text } = params;
-
-    // Verify both memories exist
-    const source = await this.readMemory({ id: source_id });
-    const target = await this.readMemory({ id: target_id });
-
-    if (!source) {
-      throw new Error(`Source memory with ID ${source_id} not found`);
-    }
-    if (!target) {
-      throw new Error(`Target memory with ID ${target_id} not found`);
-    }
-
-    // Create bidirectional links
-    await this.linkService.linkMemories({ id: source_id }, { id: target_id }, link_text);
-
-    // Update search index for both memories after linking
-    // Re-read the updated memories to get the latest state including new links
-    const updatedSource = await this.readMemory({ id: source_id });
-    const updatedTarget = await this.readMemory({ id: target_id });
+  /**
+   * Updates the search index for both source and target memories after link/unlink operations.
+   * 
+   * This helper method encapsulates the common logic for re-reading updated memories,
+   * preparing index data with custom fields, and updating the search index.
+   * 
+   * @param sourceId - ID of the source memory
+   * @param targetId - ID of the target memory
+   * @throws Error if memories or files cannot be read after the operation
+   */
+  private async updateMemorySearchIndex(sourceId: string, targetId: string): Promise<void> {
+    // Re-read the updated memories to get the latest state
+    const updatedSource = await this.readMemory({ id: sourceId });
+    const updatedTarget = await this.readMemory({ id: targetId });
 
     if (!updatedSource || !updatedTarget) {
-      throw new Error("Failed to read updated memories after linking");
+      throw new Error("Failed to read updated memories after operation");
     }
 
     // Read the raw parsed files to get all frontmatter fields including custom template fields
-    const parsedSource = await this.fileService.readMemoryFileById(source_id);
-    const parsedTarget = await this.fileService.readMemoryFileById(target_id);
+    const parsedSource = await this.fileService.readMemoryFileById(sourceId);
+    const parsedTarget = await this.fileService.readMemoryFileById(targetId);
 
     if (!parsedSource || !parsedTarget) {
-      throw new Error("Failed to read memory files after linking");
+      throw new Error("Failed to read memory files after operation");
     }
 
     // Create searchable text from custom template fields for both memories
@@ -799,6 +786,33 @@ export class MemoryService {
     // Update search index for both memories
     await this.searchService.indexMemory(sourceIndexData);
     await this.searchService.indexMemory(targetIndexData);
+  }
+
+  async linkMemories(params: LinkRequest): Promise<{
+    source_id: string;
+    target_id: string;
+    success: boolean;
+    message: string;
+  }> {
+    await this.initialize();
+    const { source_id, target_id, link_text } = params;
+
+    // Verify both memories exist
+    const source = await this.readMemory({ id: source_id });
+    const target = await this.readMemory({ id: target_id });
+
+    if (!source) {
+      throw new Error(`Source memory with ID ${source_id} not found`);
+    }
+    if (!target) {
+      throw new Error(`Target memory with ID ${target_id} not found`);
+    }
+
+    // Create bidirectional links
+    await this.linkService.linkMemories({ id: source_id }, { id: target_id }, link_text);
+
+    // Update search index for both memories after linking
+    await this.updateMemorySearchIndex(source_id, target_id);
 
     return {
       source_id,
@@ -832,75 +846,7 @@ export class MemoryService {
     await this.linkService.unlinkMemories({ id: source_id }, { id: target_id });
 
     // Update search index for both memories after unlinking
-    // Re-read the updated memories to get the latest state with links removed
-    const updatedSource = await this.readMemory({ id: source_id });
-    const updatedTarget = await this.readMemory({ id: target_id });
-
-    if (!updatedSource || !updatedTarget) {
-      throw new Error("Failed to read updated memories after unlinking");
-    }
-
-    // Read the raw parsed files to get all frontmatter fields including custom template fields
-    const parsedSource = await this.fileService.readMemoryFileById(source_id);
-    const parsedTarget = await this.fileService.readMemoryFileById(target_id);
-
-    if (!parsedSource || !parsedTarget) {
-      throw new Error("Failed to read memory files after unlinking");
-    }
-
-    // Create searchable text from custom template fields for both memories
-    const sourceCustomFieldsText = this.createSearchableCustomFieldsText(parsedSource);
-    const targetCustomFieldsText = this.createSearchableCustomFieldsText(parsedTarget);
-
-    // Prepare index data for source memory
-    const sourceIndexData: MemoryIndexDocument = {
-      id: updatedSource.id,
-      title: updatedSource.title,
-      content: updatedSource.content + sourceCustomFieldsText,
-      tags: updatedSource.tags,
-      category: updatedSource.category,
-      created_at: updatedSource.created_at,
-      updated_at: updatedSource.updated_at,
-      last_reviewed: updatedSource.last_reviewed,
-      links: updatedSource.links,
-      sources: updatedSource.sources,
-      abstract: updatedSource.abstract,
-    };
-
-    // Prepare index data for target memory
-    const targetIndexData: MemoryIndexDocument = {
-      id: updatedTarget.id,
-      title: updatedTarget.title,
-      content: updatedTarget.content + targetCustomFieldsText,
-      tags: updatedTarget.tags,
-      category: updatedTarget.category,
-      created_at: updatedTarget.created_at,
-      updated_at: updatedTarget.updated_at,
-      last_reviewed: updatedTarget.last_reviewed,
-      links: updatedTarget.links,
-      sources: updatedTarget.sources,
-      abstract: updatedTarget.abstract,
-    };
-
-    // Add any custom fields that might be present
-    const sourceCustomFields: Record<string, unknown> = {};
-    const targetCustomFields: Record<string, unknown> = {};
-    for (const key in parsedSource) {
-      if (!KNOWN_FRONTMATTER_FIELDS.has(key as any)) {
-        sourceCustomFields[key] = parsedSource[key];
-      }
-    }
-    for (const key in parsedTarget) {
-      if (!KNOWN_FRONTMATTER_FIELDS.has(key as any)) {
-        targetCustomFields[key] = parsedTarget[key];
-      }
-    }
-    Object.assign(sourceIndexData, sourceCustomFields);
-    Object.assign(targetIndexData, targetCustomFields);
-
-    // Update search index for both memories
-    await this.searchService.indexMemory(sourceIndexData);
-    await this.searchService.indexMemory(targetIndexData);
+    await this.updateMemorySearchIndex(source_id, target_id);
 
     return {
       source_id,


### PR DESCRIPTION
…ndex on memory linking/unlinking

- Introduced a mechanism in MemoryServiceManager to prevent concurrent reindex operations by tracking in-progress promises.
- Updated ensureIndexSync to wait for existing reindex operations to complete before starting a new one.
- Added doReindex method to handle the actual reindexing logic separately.
- Enhanced MemoryService to update the search index after linking and unlinking memories, ensuring the latest state is reflected in the index.
- Improved error handling for memory reads during linking and unlinking operations.